### PR TITLE
Fix missing delete handler in user listing

### DIFF
--- a/app/Livewire/Users/Index.php
+++ b/app/Livewire/Users/Index.php
@@ -29,4 +29,16 @@ class Index extends Component
 
         return view('livewire.users.index', compact('users'));
     }
+
+    /**
+     * Delete a user by id.
+     */
+    public function delete(int $id): void
+    {
+        $user = User::find($id);
+        if ($user) {
+            $user->delete();
+            session()->flash('success', 'Xóa người dùng thành công!');
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add delete method to `Users\Index` Livewire component so delete buttons work

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6852a007f5388320952ac7e37345892b