### PR TITLE
Add wire:navigate to interactive elements

### DIFF
--- a/resources/views/components/layouts/dash.blade.php
+++ b/resources/views/components/layouts/dash.blade.php
@@ -13,7 +13,7 @@
         </a>
         <div class="dropdown">
             <i class="bi bi-bell fs-5 me-3"></i>
-            <a href="#" class="fw-bold text-white text-decoration-none dropdown-toggle" id="userDropdown"
+            <a wire:navigate href="#" class="fw-bold text-white text-decoration-none dropdown-toggle" id="userDropdown"
                 data-bs-toggle="dropdown" aria-expanded="false">
                 {{ auth()->user()->name }}
                 <i class="bi bi-person-circle fs-5 ms-2"></i>
@@ -22,7 +22,7 @@
                 <li>
                     <form method="POST" action="{{ route('logout') }}">
                         @csrf
-                        <button type="submit" class="dropdown-item text-danger">
+                        <button wire:navigate type="submit" class="dropdown-item text-danger">
                             <i class="bi bi-box-arrow-right me-2"></i>Đăng xuất
                         </button>
                     </form>

--- a/resources/views/livewire/attendance/take-attendance.blade.php
+++ b/resources/views/livewire/attendance/take-attendance.blade.php
@@ -89,7 +89,7 @@
                         <div class="d-flex gap-2 justify-content-end">
                             <input wire:model.live="selectedDate" type="date" class="form-control"
                                 style="max-width: 200px;">
-                            <button wire:click="saveAttendance" class="btn btn-primary">
+                            <button wire:navigate wire:click="saveAttendance" class="btn btn-primary">
                                 <i class="bi bi-save me-2"></i>Lưu điểm danh
                             </button>
                         </div>
@@ -100,7 +100,7 @@
                 @if (session()->has('message'))
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ session('message') }}
-                        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        <button wire:navigate type="button" class="btn-close" data-bs-dismiss="alert"></button>
                     </div>
                 @endif
 
@@ -167,7 +167,7 @@
                                         </td>
                                         <td>
                                             @if (!$data['present'])
-                                                <button wire:click="openReasonModal({{ $data['student_record']->id }})"
+                                                <button wire:navigate wire:click="openReasonModal({{ $data['student_record']->id }})"
                                                     class="btn btn-sm btn-outline-primary">
                                                     <i class="bi bi-pencil me-1"></i>Lý do
                                                 </button>
@@ -192,7 +192,7 @@
                         <h5 class="modal-title">
                             <i class="bi bi-exclamation-triangle me-2"></i>Lý do nghỉ học
                         </h5>
-                        <button type="button" class="btn-close"
+                        <button wire:navigate type="button" class="btn-close"
                             wire:click="$set('showReasonModal', false)"></button>
                     </div>
                     <div class="modal-body">
@@ -206,10 +206,10 @@
                         </div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" wire:click="$set('showReasonModal', false)">
+                        <button wire:navigate type="button" class="btn btn-secondary" wire:click="$set('showReasonModal', false)">
                             Hủy
                         </button>
-                        <button type="button" class="btn btn-primary" wire:click="saveReason">
+                        <button wire:navigate type="button" class="btn btn-primary" wire:click="saveReason">
                             <i class="bi bi-check-circle me-2"></i>Lưu lý do
                         </button>
                     </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -52,7 +52,7 @@
 
                             <!-- Login Button -->
                             <div class="d-grid">
-                                <button type="submit" class="btn btn-primary btn-lg fw-semibold py-3 rounded-3">
+                                <button wire:navigate type="submit" class="btn btn-primary btn-lg fw-semibold py-3 rounded-3">
                                     <i class="bi bi-box-arrow-in-right me-2"></i>
                                     Đăng nhập
                                 </button>

--- a/resources/views/livewire/classrooms/assign-students.blade.php
+++ b/resources/views/livewire/classrooms/assign-students.blade.php
@@ -15,7 +15,7 @@
         @if (session()->has('message'))
             <div class="alert alert-success alert-dismissible fade show" role="alert">
                 {{ session('message') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <button wire:navigate type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         @endif
 
@@ -29,10 +29,10 @@
                                 <i class="bi bi-person-plus me-2"></i>Danh sách học viên có sẵn
                             </h5>
                             <div class="d-flex gap-2">
-                                <button wire:click="selectAll" class="btn btn-sm btn-outline-primary">
+                                <button wire:navigate wire:click="selectAll" class="btn btn-sm btn-outline-primary">
                                     <i class="bi bi-check-all me-1"></i>Chọn tất cả
                                 </button>
-                                <button wire:click="deselectAll" class="btn btn-sm btn-outline-secondary">
+                                <button wire:navigate wire:click="deselectAll" class="btn btn-sm btn-outline-secondary">
                                     <i class="bi bi-x-circle me-1"></i>Bỏ chọn tất cả
                                 </button>
                             </div>
@@ -246,7 +246,7 @@
 
                         <!-- Action Buttons -->
                         <div class="mt-4">
-                            <button wire:click="assignStudents" class="btn btn-primary w-100"
+                            <button wire:navigate wire:click="assignStudents" class="btn btn-primary w-100"
                                 {{ empty($selectedStudents) && $enrolledStudents->count() == 0 ? 'disabled' : '' }}>
                                 <i class="bi bi-check-circle me-2"></i>
                                 Cập nhật danh sách học viên

--- a/resources/views/livewire/classrooms/create.blade.php
+++ b/resources/views/livewire/classrooms/create.blade.php
@@ -122,7 +122,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('classrooms.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-book me-2"></i>Tạo lớp học
                         </button>
                     </div>

--- a/resources/views/livewire/classrooms/edit.blade.php
+++ b/resources/views/livewire/classrooms/edit.blade.php
@@ -122,7 +122,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('classrooms.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-save me-2"></i>Lưu thay đổi
                         </button>
                     </div>

--- a/resources/views/livewire/classrooms/index.blade.php
+++ b/resources/views/livewire/classrooms/index.blade.php
@@ -87,7 +87,7 @@
                                                 class="btn btn-sm btn-outline-primary" title="Chỉnh sửa">
                                                 <i class="bi bi-pencil-square"></i>
                                             </a>
-                                            <button type="button" data-bs-toggle="modal"
+                                            <button wire:navigate type="button" data-bs-toggle="modal"
                                                 data-bs-target="#deleteModal{{ $classroom->id }}"
                                                 class="btn btn-sm btn-outline-danger" title="Xóa">
                                                 <i class="bi bi-trash"></i>
@@ -105,7 +105,7 @@
                                             <div class="modal-header">
                                                 <h5 class="modal-title" id="deleteModalLabel{{ $classroom->id }}">
                                                     Xác nhận xóa lớp học</h5>
-                                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                                <button wire:navigate type="button" class="btn-close" data-bs-dismiss="modal"
                                                     aria-label="Close"></button>
                                             </div>
 
@@ -115,9 +115,9 @@
                                             </div>
 
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary"
+                                                <button wire:navigate type="button" class="btn btn-secondary"
                                                     data-bs-dismiss="modal">Hủy</button>
-                                                <button type="button" class="btn btn-danger" id="confirmDelete"
+                                                <button wire:navigate type="button" class="btn btn-danger" id="confirmDelete"
                                                     wire:click="delete({{ $classroom->id }})"
                                                     data-bs-dismiss="modal">Xóa</button>
                                             </div>

--- a/resources/views/livewire/schedules/edit.blade.php
+++ b/resources/views/livewire/schedules/edit.blade.php
@@ -6,7 +6,7 @@
                     <div class="card-header">
                         <div class="d-flex justify-content-between align-items-center">
                             <h4 class="mb-0 fs-4">Chỉnh sửa lịch học</h4>
-                            <a href="{{ route('schedules.index') }}" class="btn btn-outline-secondary">
+                            <a wire:navigate href="{{ route('schedules.index') }}" class="btn btn-outline-secondary">
                                 <i class="bi bi-arrow-left me-2"></i>Quay lại
                             </a>
                         </div>
@@ -96,10 +96,10 @@
 
                             <!-- Nút thao tác -->
                             <div class="d-flex justify-content-end gap-2">
-                                <a href="{{ route('schedules.index') }}" class="btn btn-secondary">
+                                <a wire:navigate href="{{ route('schedules.index') }}" class="btn btn-secondary">
                                     <i class="bi bi-x-circle me-2"></i>Hủy
                                 </a>
-                                <button type="submit" class="btn btn-primary">
+                                <button wire:navigate type="submit" class="btn btn-primary">
                                     <i class="bi bi-check-circle me-2"></i>Lưu thay đổi
                                 </button>
                             </div>

--- a/resources/views/livewire/schedules/index.blade.php
+++ b/resources/views/livewire/schedules/index.blade.php
@@ -5,7 +5,7 @@
                 <i class="bi bi-calendar3 me-2 text-primary"></i>
                 Lịch học
             </h2>
-            <a href="{{ route('schedules.create') }}" class="btn btn-primary">
+            <a wire:navigate href="{{ route('schedules.create') }}" class="btn btn-primary">
                 <i class="bi bi-plus-circle me-2"></i>Thêm lịch học
             </a>
         </div>
@@ -38,7 +38,7 @@
                         </select>
                     </div>
                     <div class="col-md-2 d-flex align-items-end">
-                        <button wire:click="$set('search', '')" wire:click="$set('filterLevel', '')"
+                        <button wire:navigate wire:click="$set('search', '')" wire:click="$set('filterLevel', '')"
                             wire:click="$set('filterTeacher', '')" class="btn btn-outline-secondary w-100">
                             <i class="bi bi-arrow-clockwise me-1"></i>Làm mới
                         </button>
@@ -104,11 +104,11 @@
                                         </td>
                                         <td>
                                             <div class="btn-group" role="group">
-                                                <a href="{{ route('schedules.show', $classroom) }}"
+                                                <a wire:navigate href="{{ route('schedules.show', $classroom) }}"
                                                     class="btn btn-sm btn-outline-primary" title="Xem chi tiết">
                                                     <i class="bi bi-eye"></i>
                                                 </a>
-                                                <a href="{{ route('schedules.edit', $classroom) }}"
+                                                <a wire:navigate href="{{ route('schedules.edit', $classroom) }}"
                                                     class="btn btn-sm btn-outline-warning" title="Chỉnh sửa">
                                                     <i class="bi bi-pencil"></i>
                                                 </a>

--- a/resources/views/livewire/schedules/show.blade.php
+++ b/resources/views/livewire/schedules/show.blade.php
@@ -3,10 +3,10 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h2 class="mb-0 fs-4">Chi tiết lịch học</h2>
             <div class="btn-group" role="group">
-                <a href="{{ route('schedules.index') }}" class="btn btn-outline-secondary">
+                <a wire:navigate href="{{ route('schedules.index') }}" class="btn btn-outline-secondary">
                     <i class="bi bi-arrow-left me-2"></i>Quay lại
                 </a>
-                <a href="{{ route('schedules.edit', $classroom) }}" class="btn btn-warning">
+                <a wire:navigate href="{{ route('schedules.edit', $classroom) }}" class="btn btn-warning">
                     <i class="bi bi-pencil me-2"></i>Chỉnh sửa
                 </a>
             </div>
@@ -130,7 +130,7 @@
                             <div class="text-center py-4">
                                 <i class="bi bi-calendar-x" style="font-size: 3rem; color: #6c757d;"></i>
                                 <h6 class="mt-3 text-muted">Chưa có lịch học</h6>
-                                <a href="{{ route('schedules.edit', $classroom) }}" class="btn btn-primary">
+                                <a wire:navigate href="{{ route('schedules.edit', $classroom) }}" class="btn btn-primary">
                                     <i class="bi bi-plus-circle me-2"></i>Thêm lịch học
                                 </a>
                             </div>

--- a/resources/views/livewire/students/create.blade.php
+++ b/resources/views/livewire/students/create.blade.php
@@ -149,7 +149,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('students.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-person-plus me-2"></i>Thêm học viên
                         </button>
                     </div>

--- a/resources/views/livewire/students/edit.blade.php
+++ b/resources/views/livewire/students/edit.blade.php
@@ -140,7 +140,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('students.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-check-circle me-2"></i>Cập nhật
                         </button>
                     </div>

--- a/resources/views/livewire/students/index.blade.php
+++ b/resources/views/livewire/students/index.blade.php
@@ -13,7 +13,7 @@
         @if (session()->has('message'))
             <div class="alert alert-success alert-dismissible fade show" role="alert">
                 {{ session('message') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                <button wire:navigate type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         @endif
 
@@ -47,7 +47,7 @@
                         </select>
                     </div>
                     <div class="col-md-2 mb-3">
-                        <button wire:click="resetFilters" class="btn btn-outline-secondary w-100">
+                        <button wire:navigate wire:click="resetFilters" class="btn btn-outline-secondary w-100">
                             <i class="bi bi-arrow-clockwise me-1"></i>Reset
                         </button>
                     </div>
@@ -153,7 +153,7 @@
                                                 class="btn btn-sm btn-outline-primary" title="Chỉnh sửa">
                                                 <i class="bi bi-pencil-square"></i>
                                             </a>
-                                            <button type="button" data-bs-toggle="modal"
+                                            <button wire:navigate type="button" data-bs-toggle="modal"
                                                 data-bs-target="#deleteModal{{ $student->id }}"
                                                 class="btn btn-sm btn-outline-danger" title="Xóa">
                                                 <i class="bi bi-trash"></i>
@@ -170,7 +170,7 @@
                                             <div class="modal-header">
                                                 <h5 class="modal-title" id="deleteModalLabel{{ $student->id }}">
                                                     Xác nhận xóa học viên</h5>
-                                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                                <button wire:navigate type="button" class="btn-close" data-bs-dismiss="modal"
                                                     aria-label="Close"></button>
                                             </div>
                                             <div class="modal-body">
@@ -178,9 +178,9 @@
                                                 này không thể hoàn tác.
                                             </div>
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary"
+                                                <button wire:navigate type="button" class="btn btn-secondary"
                                                     data-bs-dismiss="modal">Hủy</button>
-                                                <button type="button" class="btn btn-danger"
+                                                <button wire:navigate type="button" class="btn btn-danger"
                                                     wire:click="delete({{ $student->id }})"
                                                     data-bs-dismiss="modal">Xóa</button>
                                             </div>

--- a/resources/views/livewire/users/create.blade.php
+++ b/resources/views/livewire/users/create.blade.php
@@ -94,7 +94,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('users.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-person-plus-fill me-2"></i>Tạo người dùng
                         </button>
                     </div>

--- a/resources/views/livewire/users/edit.blade.php
+++ b/resources/views/livewire/users/edit.blade.php
@@ -94,7 +94,7 @@
                     <!-- Submit Buttons -->
                     <div class="d-flex justify-content-end gap-2">
                         <a href="{{ route('users.index') }}" wire:navigate class="btn btn-light">Hủy</a>
-                        <button type="submit" class="btn btn-primary">
+                        <button wire:navigate type="submit" class="btn btn-primary">
                             <i class="bi bi-save me-2"></i>Lưu thay đổi
                         </button>
                     </div>

--- a/resources/views/livewire/users/index.blade.php
+++ b/resources/views/livewire/users/index.blade.php
@@ -67,11 +67,11 @@
                                     </td>
                                     <td>
                                         <div class="d-flex justify-content-end gap-2">
-                                            <a href="{{ route('users.edit', $user->id) ?? '#' }}" wire:navigate
+                                            <a wire:navigate href="{{ route('users.edit', $user->id) ?? '#' }}"
                                                 class="btn btn-sm btn-outline-primary" title="Sửa">
                                                 <i class="bi bi-pencil-square"></i>
                                             </a>
-                                            <button type="button" data-bs-toggle="modal"
+                                            <button wire:navigate type="button" data-bs-toggle="modal"
                                                 data-bs-target="#deleteModal{{ $user->id }}"
                                                 class="btn btn-sm btn-outline-danger" title="Xóa">
                                                 <i class="bi bi-trash"></i>
@@ -89,7 +89,7 @@
                                             <div class="modal-header">
                                                 <h5 class="modal-title" id="deleteModalLabel{{ $user->id }}">
                                                     Xác nhận xóa người dùng</h5>
-                                                <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                                <button wire:navigate type="button" class="btn-close" data-bs-dismiss="modal"
                                                     aria-label="Close"></button>
                                             </div>
 
@@ -99,9 +99,9 @@
                                             </div>
 
                                             <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary"
+                                                <button wire:navigate type="button" class="btn btn-secondary"
                                                     data-bs-dismiss="modal">Hủy</button>
-                                                <button type="button" class="btn btn-danger" id="confirmDelete"
+                                                <button wire:navigate type="button" class="btn btn-danger" id="confirmDelete"
                                                     wire:click="delete({{ $user->id }})"
                                                     data-bs-dismiss="modal">Xóa</button>
                                             </div>


### PR DESCRIPTION
## Summary
- enable Livewire navigation on anchors and buttons across the UI

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6854d56b84788320ae9c9cb11188a34a