### PR TITLE
Persist locale selection using cookies

### DIFF
--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -4,15 +4,18 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Cookie;
 
 class SetLocale
 {
     public function handle($request, Closure $next)
     {
-        $locale = Session::get('locale', config('app.locale'));
+        $locale = Session::get('locale', Cookie::get('locale', config('app.locale')));
 
         if (in_array($locale, ['vi', 'en', 'zh'])) {
             App::setLocale($locale);
+            Session::put('locale', $locale);
+            Cookie::queue('locale', $locale, 60 * 24 * 365);
         }
 
         return $next($request);

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use App\Livewire\Auth\Login;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Cookie;
 use App\Livewire\Admin\Grading\GradingList;
 use App\Livewire\Admin\Grading\GradeAssignment;
 use App\Livewire\Admin\Users\Edit as UsersEdit;
@@ -36,6 +37,7 @@ Route::get('/', function () {
 Route::get('/lang/{locale}', function ($locale) {
     if (in_array($locale, ['vi', 'en', 'zh'])) {
         session(['locale' => $locale]);
+        Cookie::queue('locale', $locale, 60 * 24 * 365);
     }
     return redirect()->back();
 })->name('lang.switch');

--- a/tests/Feature/LocaleSwitchTest.php
+++ b/tests/Feature/LocaleSwitchTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class LocaleSwitchTest extends TestCase
+{
+    /** @test */
+    public function it_switches_locale_and_persists_in_cookie_and_session()
+    {
+        $response = $this->get('/lang/en');
+
+        $response->assertStatus(302);
+        $response->assertCookie('locale', 'en');
+        $this->assertEquals('en', session('locale'));
+
+        $this->get('/test-locale')
+            ->assertJsonFragment([
+                'current_locale' => 'en',
+                'session_locale' => 'en',
+                'cookie_locale' => 'en',
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- persist locale preference in both session and cookie
- fall back to locale cookie during middleware initialization
- test locale switching and persistence

## Testing
- `composer install` *(failed: CONNECT tunnel failed / GitHub 403)*
- `./vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891361df504833182fedacc5f05d57d